### PR TITLE
feat: implement awx - toggle between current and previous environment (closes #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Fast AWS Profile & EKS Context Switching for DevOps and Cloud Engineers_
 - Fuzzy, interactive AWS profile selection via [`fzf`](https://github.com/junegunn/fzf)
 - Non-interactive mode: `awx use --profile X --cluster Y` for scripts and automation
 - Profile shortcut: `awx profile-name` as an alias for `awx use --profile profile-name`
+- **`awx -`** — Toggle back to the previous AWS profile and EKS cluster (like `cd -` / `git checkout -`)
 - Zsh tab completion for commands, subcommands, and AWS profile names
 - SSO login automation; minimal credential hassle
 - Automatically updates current [`kubeconfig`](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
@@ -46,6 +47,16 @@ awx eks update                               # Update kubeconfig for a specific 
 awx help or -h                               # Show detailed usage instructions
 awx logout                                   # Logout of the current AWS SSO session
 ```
+
+### Toggle to previous environment
+
+Switch back to the last used profile/cluster:
+
+```bash
+awx -
+```
+
+Running `awx -` again toggles back to the original environment. State is persisted across shell sessions in `~/.local/state/awx/env`.
 
 ### Example Workflow
 ```sh

--- a/awx
+++ b/awx
@@ -39,7 +39,8 @@ _awx_state_write() {
   printf "%s\n%s\n" "${profile},${cluster}" "${prev_current}" >"$AWX_STATE_FILE"
 }
 
-# Read the previous environment line. Prints "profile,cluster" or empty string.
+# Read the previous environment line. Prints "profile,cluster", empty string, or blank line.
+# Callers must guard against empty/blank results.
 _awx_state_read_previous() {
   if [[ ! -f "$AWX_STATE_FILE" ]]; then
     return 0

--- a/awx
+++ b/awx
@@ -13,6 +13,40 @@ AWX_EKS_RETRIES="${AWX_EKS_RETRIES:-3}"         # Retries for EKS API calls afte
 AWX_EKS_RETRY_DELAY="${AWX_EKS_RETRY_DELAY:-2}" # Seconds between EKS API retries
 AWX_STS_RETRIES="${AWX_STS_RETRIES:-10}"        # Retries waiting for STS after SSO login
 
+# ---------------------------------------------------------------------------
+# State management — persists current/previous environment for `awx -`
+# ---------------------------------------------------------------------------
+AWX_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/awx"
+AWX_STATE_FILE="${AWX_STATE_FILE:-$AWX_STATE_DIR/env}"
+
+_awx_state_ensure_dir() {
+  mkdir -p "$(dirname "$AWX_STATE_FILE")"
+}
+
+# Write a new current env, rotating previous.
+# Usage: _awx_state_write <profile> <cluster>
+_awx_state_write() {
+  local profile="$1"
+  local cluster="${2:-}"
+  local prev_current=""
+
+  _awx_state_ensure_dir
+
+  if [[ -f "$AWX_STATE_FILE" ]]; then
+    prev_current="$(head -1 "$AWX_STATE_FILE")"
+  fi
+
+  printf "%s\n%s\n" "${profile},${cluster}" "${prev_current}" >"$AWX_STATE_FILE"
+}
+
+# Read the previous environment line. Prints "profile,cluster" or empty string.
+_awx_state_read_previous() {
+  if [[ ! -f "$AWX_STATE_FILE" ]]; then
+    return 0
+  fi
+  sed -n '2p' "$AWX_STATE_FILE"
+}
+
 log() {
   printf "[INFO] %s\n" "$*"
 }

--- a/awx
+++ b/awx
@@ -304,6 +304,41 @@ awx_logout() {
   fi
 }
 
+awx_prev() {
+  local prev_line
+  prev_line="$(_awx_state_read_previous)"
+
+  # Strip whitespace/blank lines
+  prev_line="${prev_line#"${prev_line%%[![:space:]]*}"}"
+  prev_line="${prev_line%"${prev_line##*[![:space:]]}"}"
+
+  if [[ -z "$prev_line" ]]; then
+    die "No previous environment recorded. Run 'awx use' at least twice to enable toggling."
+  fi
+
+  local prev_profile prev_cluster
+  prev_profile="${prev_line%%,*}"
+  prev_cluster="${prev_line#*,}"
+
+  # Swap state lines: previous becomes current, current becomes previous
+  local current_line=""
+  if [[ -f "$AWX_STATE_FILE" ]]; then
+    current_line="$(head -1 "$AWX_STATE_FILE")"
+  fi
+  _awx_state_ensure_dir
+  printf "%s\n%s\n" "$prev_line" "$current_line" >"$AWX_STATE_FILE"
+
+  export AWS_PROFILE="$prev_profile"
+  export AWS_REGION="$DEFAULT_REGION"
+  log "Switched to profile: $AWS_PROFILE (region: $AWS_REGION)"
+
+  if [[ -n "$prev_cluster" ]]; then
+    _eks_update_kubeconfig "$prev_profile" "$prev_cluster" "$DEFAULT_REGION"
+  else
+    warn "No cluster stored for previous environment; kubeconfig not updated"
+  fi
+}
+
 show_help() {
   echo "Usage: awx [command]"
   echo "Commands:"
@@ -336,6 +371,9 @@ awx() {
       ;;
     help | -h)
       show_help
+      ;;
+    -)
+      awx_prev
       ;;
     --*)
       # Top-level flags (e.g. awx --profile X) forwarded directly to awx_use.

--- a/awx
+++ b/awx
@@ -313,7 +313,8 @@ awx_prev() {
   prev_line="${prev_line%"${prev_line##*[![:space:]]}"}"
 
   if [[ -z "$prev_line" ]]; then
-    die "No previous environment recorded. Run 'awx use' at least twice to enable toggling."
+    warn "No previous environment recorded; staying on current profile: ${AWS_PROFILE:-<unset>}"
+    return 0
   fi
 
   if [[ "$prev_line" != *,* ]]; then

--- a/awx
+++ b/awx
@@ -355,6 +355,7 @@ show_help() {
   echo "  eks list                          List EKS clusters for the active profile"
   echo "  eks update                        Update kubeconfig for a specific EKS cluster"
   echo "  logout                            Logout of the current AWS SSO session"
+  echo "  -                                 Toggle back to previous AWS profile/cluster (like cd -)"
   echo "  help | -h                         Show this help message"
 }
 

--- a/awx
+++ b/awx
@@ -233,11 +233,13 @@ awx_use() {
 
   if [[ -z "$cluster" ]]; then
     if ! cluster="$(select_cluster_for_profile "$profile")"; then
+      _awx_state_write "$profile" ""
       return 0
     fi
   fi
 
   _eks_update_kubeconfig "$profile" "$cluster" "$DEFAULT_REGION"
+  _awx_state_write "$profile" "$cluster"
 }
 
 awx_whoami() {
@@ -277,6 +279,7 @@ awx_eks() {
     update)
       cluster="$(select_cluster_for_profile "$profile")" || die "No EKS cluster selected"
       _eks_update_kubeconfig "$profile" "$cluster" "$DEFAULT_REGION"
+      _awx_state_write "$profile" "$cluster"
       ;;
     *)
       die "Unknown eks subcommand: ${subcommand:-<empty>} (expected: list|update)"

--- a/awx
+++ b/awx
@@ -316,6 +316,10 @@ awx_prev() {
     die "No previous environment recorded. Run 'awx use' at least twice to enable toggling."
   fi
 
+  if [[ "$prev_line" != *,* ]]; then
+    die "Malformed state entry: '$prev_line'. Expected 'profile,cluster' format. Delete ${AWX_STATE_FILE} to reset."
+  fi
+
   local prev_profile prev_cluster
   prev_profile="${prev_line%%,*}"
   prev_cluster="${prev_line#*,}"
@@ -326,6 +330,9 @@ awx_prev() {
     current_line="$(head -1 "$AWX_STATE_FILE")"
   fi
   _awx_state_ensure_dir
+  # NOTE: state is swapped before kubeconfig update. If kubeconfig fails,
+  # the state file reflects the new environment even though kubeconfig was
+  # not updated. Run 'awx -' again to recover or manually run 'awx use'.
   printf "%s\n%s\n" "$prev_line" "$current_line" >"$AWX_STATE_FILE"
 
   export AWS_PROFILE="$prev_profile"

--- a/tests/cli_flags.bats
+++ b/tests/cli_flags.bats
@@ -28,10 +28,15 @@ EOF
 exec /usr/bin/jq "$@"
 EOF
   chmod +x mock/bin/jq
+
+  export AWX_STATE_FILE
+  AWX_STATE_FILE="$(mktemp)"
+  rm -f "$AWX_STATE_FILE"
 }
 
 teardown() {
   rm -rf mock
+  rm -f "${AWX_STATE_FILE:-}"
 }
 
 # ---------------------------------------------------------------------------
@@ -40,7 +45,7 @@ teardown() {
 @test "awx use --profile X sets profile non-interactively" {
   # fzf is NOT mocked — if it were called it would fail (not in PATH)
   # The test succeeds only if fzf is never invoked for profile selection.
-  run ./awx use --profile mock-profile
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx use --profile mock-profile
 
   [ "$status" -eq 0 ]
   [[ "${output}" =~ "Using profile: mock-profile" ]]
@@ -51,7 +56,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 @test "awx use --profile X --cluster Y is fully non-interactive" {
   # fzf is NOT mocked — test passes only if fzf is never called.
-  run ./awx use --profile mock-profile --cluster mock-cluster
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx use --profile mock-profile --cluster mock-cluster
 
   [ "$status" -eq 0 ]
   [[ "${output}" =~ "Using profile: mock-profile" ]]
@@ -62,7 +67,7 @@ teardown() {
 # Test 3: awx <profile> shortcut behaves like awx use --profile <profile>
 # ---------------------------------------------------------------------------
 @test "awx <profile> shortcut sets profile non-interactively" {
-  run ./awx mock-profile
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx mock-profile
 
   [ "$status" -eq 0 ]
   [[ "${output}" =~ "Using profile: mock-profile" ]]
@@ -72,7 +77,7 @@ teardown() {
 # Test 4: Unknown flag exits with an error
 # ---------------------------------------------------------------------------
 @test "awx use --invalid-flag exits non-zero with error" {
-  run ./awx use --invalid-flag
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx use --invalid-flag
 
   [ "$status" -ne 0 ]
   [[ "${output}" =~ "Unknown flag" ]] || [[ "${output}" =~ "ERROR" ]]
@@ -89,7 +94,7 @@ echo "mock-profile"
 EOF
   chmod +x mock/bin/fzf
 
-  run ./awx use
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx use
 
   [ "$status" -eq 0 ]
   [[ "${output}" =~ "Using profile: mock-profile" ]]
@@ -100,7 +105,7 @@ EOF
 # Regression test: previously treated --profile as the profile name itself
 # ---------------------------------------------------------------------------
 @test "awx --profile X (top-level flag) sets profile non-interactively" {
-  run ./awx --profile mock-profile
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx --profile mock-profile
 
   [ "$status" -eq 0 ]
   [[ "${output}" =~ "Using profile: mock-profile" ]]

--- a/tests/prev_env.bats
+++ b/tests/prev_env.bats
@@ -107,23 +107,26 @@ EOM
   [[ "$(sed -n '2p' "$AWX_STATE_FILE")" == "dev-profile,dev-cluster" ]]
 }
 
-@test "awx - with no state file exits non-zero with message" {
+@test "awx - with no state file stays on current profile with warning" {
   rm -f "$AWX_STATE_FILE"
+  export AWS_PROFILE="current-profile"
 
   AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx - 2>&1
 
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 0 ]
   [[ "${output}" =~ "No previous environment recorded" ]]
+  [[ "${output}" =~ "current-profile" ]]
 }
 
-@test "awx - with empty previous env exits non-zero with message" {
+@test "awx - with empty previous env stays on current profile with warning" {
   printf "prod-profile,prod-cluster\n\n" >"$AWX_STATE_FILE"
   export AWS_PROFILE="prod-profile"
 
   AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx - 2>&1
 
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 0 ]
   [[ "${output}" =~ "No previous environment recorded" ]]
+  [[ "${output}" =~ "prod-profile" ]]
 }
 
 @test "awx - with profile-only previous env switches profile and warns" {

--- a/tests/prev_env.bats
+++ b/tests/prev_env.bats
@@ -4,7 +4,6 @@ setup() {
   export AWX_STATE_FILE="$(mktemp)"
   rm -f "$AWX_STATE_FILE"  # start empty
   mkdir -p "$(dirname "$AWX_STATE_FILE")"
-  export AWX_TEST_STATE_FILE="$AWX_STATE_FILE"
 }
 
 teardown() {

--- a/tests/prev_env.bats
+++ b/tests/prev_env.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+setup() {
+  export AWX_STATE_FILE="$(mktemp)"
+  rm -f "$AWX_STATE_FILE"  # start empty
+  mkdir -p "$(dirname "$AWX_STATE_FILE")"
+  export AWX_TEST_STATE_FILE="$AWX_STATE_FILE"
+}
+
+teardown() {
+  rm -f "${AWX_STATE_FILE:-}"
+  rm -rf mock
+}
+
+@test "state file is created after awx use with profile and cluster" {
+  mkdir -p mock/bin
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/aws <<'EOM'
+#!/bin/bash
+if [[ "$*" == configure* ]]; then echo "eu-central-1"
+elif [[ "$*" == sts* ]]; then echo '{"UserId":"X","Account":"123","Arn":"arn:aws:iam::123:user/x"}'
+elif [[ "$*" == eks\ list-clusters* ]]; then echo '{"clusters":["test-cluster"]}'
+elif [[ "$*" == eks\ update-kubeconfig* ]]; then exit 0
+fi
+EOM
+  chmod +x mock/bin/aws
+
+  cat >mock/bin/fzf <<'EOM'
+#!/bin/bash
+echo "test-profile"
+EOM
+  chmod +x mock/bin/fzf
+
+  cat >mock/bin/jq <<'EOM'
+#!/bin/bash
+if [[ "$*" == -e* ]]; then exit 0; fi
+cat
+EOM
+  chmod +x mock/bin/jq
+
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx use
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWX_STATE_FILE" ]
+  head -1 "$AWX_STATE_FILE" | grep -q "test-profile"
+}

--- a/tests/prev_env.bats
+++ b/tests/prev_env.bats
@@ -103,6 +103,8 @@ EOM
   [ "$status" -eq 0 ]
 
   grep -q "prod-profile" <(head -1 "$AWX_STATE_FILE")
+  [[ "$(head -1 "$AWX_STATE_FILE")" == "prod-profile,prod-cluster" ]]
+  [[ "$(sed -n '2p' "$AWX_STATE_FILE")" == "dev-profile,dev-cluster" ]]
 }
 
 @test "awx - with no state file exits non-zero with message" {

--- a/tests/prev_env.bats
+++ b/tests/prev_env.bats
@@ -44,3 +44,104 @@ EOM
   [ -f "$AWX_STATE_FILE" ]
   head -1 "$AWX_STATE_FILE" | grep -q "test-profile"
 }
+
+@test "awx - toggles between two environments" {
+  mkdir -p mock/bin
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/aws <<'EOM'
+#!/bin/bash
+if [[ "$*" == configure* ]]; then echo "eu-central-1"
+elif [[ "$*" == sts* ]]; then echo '{"UserId":"X","Account":"123","Arn":"arn"}'
+elif [[ "$*" == eks\ update-kubeconfig* ]]; then exit 0
+fi
+EOM
+  chmod +x mock/bin/aws
+
+  cat >mock/bin/jq <<'EOM'
+#!/bin/bash
+if [[ "$*" == -e* ]]; then exit 0; fi
+cat
+EOM
+  chmod +x mock/bin/jq
+
+  # Seed state file: current=prod-profile,prod-cluster  previous=dev-profile,dev-cluster
+  printf "prod-profile,prod-cluster\ndev-profile,dev-cluster\n" >"$AWX_STATE_FILE"
+  export AWS_PROFILE="prod-profile"
+
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx -
+
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "dev-profile" ]]
+  # After toggle, state should be swapped
+  grep -q "dev-profile" <(head -1 "$AWX_STATE_FILE")
+  grep -q "prod-profile" <(sed -n '2p' "$AWX_STATE_FILE")
+}
+
+@test "awx - twice returns to original environment" {
+  mkdir -p mock/bin
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/aws <<'EOM'
+#!/bin/bash
+if [[ "$*" == configure* ]]; then echo "eu-central-1"
+elif [[ "$*" == sts* ]]; then echo '{"UserId":"X","Account":"123","Arn":"arn"}'
+elif [[ "$*" == eks\ update-kubeconfig* ]]; then exit 0
+fi
+EOM
+  chmod +x mock/bin/aws
+
+  printf "prod-profile,prod-cluster\ndev-profile,dev-cluster\n" >"$AWX_STATE_FILE"
+  export AWS_PROFILE="prod-profile"
+
+  # First toggle: should switch to dev
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx -
+  [ "$status" -eq 0 ]
+
+  # Second toggle: should switch back to prod
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx -
+  [ "$status" -eq 0 ]
+
+  grep -q "prod-profile" <(head -1 "$AWX_STATE_FILE")
+}
+
+@test "awx - with no state file exits non-zero with message" {
+  rm -f "$AWX_STATE_FILE"
+
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx - 2>&1
+
+  [ "$status" -ne 0 ]
+  [[ "${output}" =~ "No previous environment recorded" ]]
+}
+
+@test "awx - with empty previous env exits non-zero with message" {
+  printf "prod-profile,prod-cluster\n\n" >"$AWX_STATE_FILE"
+  export AWS_PROFILE="prod-profile"
+
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx - 2>&1
+
+  [ "$status" -ne 0 ]
+  [[ "${output}" =~ "No previous environment recorded" ]]
+}
+
+@test "awx - with profile-only previous env switches profile and warns" {
+  mkdir -p mock/bin
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/aws <<'EOM'
+#!/bin/bash
+if [[ "$*" == configure* ]]; then echo "eu-central-1"
+elif [[ "$*" == sts* ]]; then echo '{"UserId":"X","Account":"123","Arn":"arn"}'
+fi
+EOM
+  chmod +x mock/bin/aws
+
+  printf "prod-profile,prod-cluster\ndev-profile,\n" >"$AWX_STATE_FILE"
+  export AWS_PROFILE="prod-profile"
+
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx - 2>&1
+
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "dev-profile" ]]
+  [[ "${output}" =~ "No cluster stored" ]]
+}

--- a/tests/use.bats
+++ b/tests/use.bats
@@ -1,5 +1,16 @@
 #!/usr/bin/env bats
 
+setup() {
+  export AWX_STATE_FILE
+  AWX_STATE_FILE="$(mktemp)"
+  rm -f "$AWX_STATE_FILE"
+}
+
+teardown() {
+  rm -f "${AWX_STATE_FILE:-}"
+  rm -rf mock
+}
+
 @test "awx use selects an AWS profile" {
   export PATH="$(pwd)/mock/bin:$PATH"
   mkdir -p mock/bin
@@ -9,21 +20,18 @@
   chmod +x mock/bin/fzf
 
   # Execute the command
-  run ./awx use
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx use
 
   # Verify output contains profile name
   [ "$status" -eq 0 ]
   [[ "${output}" =~ "Using profile: mock-profile" ]]
-
-  # Cleanup
-  rm -rf mock
 }
 
 @test "awx use gracefully fails without fzf" {
   PATH_BACKUP="$PATH"
   PATH="/usr/bin:/bin"
 
-  run ./awx use # Update to verify alternative error messages as "cannot locate fzf"
+  AWX_STATE_FILE="$AWX_STATE_FILE" run ./awx use # Update to verify alternative error messages as "cannot locate fzf"
 
   [ "$status" -ne 0 ] # Ensure error status
   [ -z "$fzf" ] || skip "Unhandled dependency for fzf-testing detected dynamically"


### PR DESCRIPTION
## Summary

- Adds `awx -` command that toggles between the current and previous AWS profile + EKS cluster (consistent with `cd -` / `git checkout -` semantics)
- State is persisted in `${XDG_STATE_HOME:-$HOME/.local/state}/awx/env` as a 2-line CSV
- State is updated on every successful `awx use` and `awx eks update`
- Gracefully handles missing state, empty previous env, profile-only state (no cluster), and malformed state entries
- 6 new bats tests in `tests/prev_env.bats` covering toggle, double-toggle, missing state, empty previous, and profile-only previous

Closes #33