### PR TITLE
feat(profiles): display remaining SSO session lifetime in awx profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Blazginly Fast AWS Profile & EKS Context Switcher_
 - Zsh tab completion for commands, subcommands, and AWS profile names
 - Automatic SSO session re-authentication on every profile switch: if your session expires mid-day, `awx` detects it and re-authenticates transparently, with graceful fallback to static credentials when SSO fails
 - EKS kubeconfig management with caching that skips redundant updates when the target context already exists
-- Lists all configured AWS profiles with `ACTIVE`/`EXPIRED` session status via **`awx profiles`**
+- Lists all configured AWS profiles with `ACTIVE`/`EXPIRED` session status and remaining SSO session lifetime via **`awx profiles`**
 
 ## Usage
 `awx` is a versatile script for managing AWS profiles and EKS kubeconfig contexts. Below are the primary commands and their purposes:
@@ -43,7 +43,7 @@ awx eks list                                 # List available EKS clusters for a
 awx eks update                               # Update kubeconfig for a specific cluster
 awx help or -h                               # Show detailed usage instructions
 awx logout                                   # Logout of the current AWS SSO session
-awx profiles                                 # List all configured AWS profiles with ACTIVE/EXPIRED session status
+awx profiles                                 # List all configured AWS profiles with ACTIVE/EXPIRED status and remaining session time
 awx update                                   # Update awx to the latest version from GitHub
 ```
 

--- a/awx
+++ b/awx
@@ -25,10 +25,11 @@ else
   COL_RESET=""
 fi
 
-AWX_EKS_RETRIES="${AWX_EKS_RETRIES:-3}"         # Retries for EKS API calls after SSO login
-AWX_EKS_RETRY_DELAY="${AWX_EKS_RETRY_DELAY:-2}" # Seconds between EKS API retries
-AWX_STS_RETRIES="${AWX_STS_RETRIES:-10}"        # Retries waiting for STS after SSO login
-AWX_NO_ASCII="${AWX_NO_ASCII:-false}"           # Set to "true" to suppress ASCII art banner
+AWX_EKS_RETRIES="${AWX_EKS_RETRIES:-3}"                        # Retries for EKS API calls after SSO login
+AWX_EKS_RETRY_DELAY="${AWX_EKS_RETRY_DELAY:-2}"                # Seconds between EKS API retries
+AWX_STS_RETRIES="${AWX_STS_RETRIES:-10}"                       # Retries waiting for STS after SSO login
+AWX_NO_ASCII="${AWX_NO_ASCII:-false}"                          # Set to "true" to suppress ASCII art banner
+AWX_SSO_CACHE_DIR="${AWX_SSO_CACHE_DIR:-$HOME/.aws/sso/cache}" # SSO token cache directory
 
 # ---------------------------------------------------------------------------
 # EKS cluster cache — avoids repeated AWS API calls
@@ -432,11 +433,70 @@ awx_whoami() {
   aws_call "$profile" sts get-caller-identity
 }
 
+# ---------------------------------------------------------------------------
+# Helpers for `awx profiles` session duration display
+# ---------------------------------------------------------------------------
+
+format_duration() {
+  local seconds=$1
+  local hours=$((seconds / 3600))
+  local minutes=$(((seconds % 3600) / 60))
+
+  if [[ $hours -gt 0 ]] && [[ $minutes -gt 0 ]]; then
+    printf "%dh %dm" "$hours" "$minutes"
+  elif [[ $hours -gt 0 ]]; then
+    printf "%dh" "$hours"
+  elif [[ $minutes -gt 0 ]]; then
+    printf "%dm" "$minutes"
+  else
+    printf "<1m"
+  fi
+}
+
+_sso_remaining() {
+  local profile="$1"
+  local start_url cache_dir cache_file expires_at
+  local normalized expiry_epoch now_epoch remaining
+
+  start_url="$(AWS_PAGER="" aws configure get sso_start_url --profile "$profile" 2>/dev/null || true)"
+  start_url="${start_url// /}"
+
+  [[ -n "$start_url" ]] || return 0
+
+  cache_dir="$AWX_SSO_CACHE_DIR"
+  [[ -d "$cache_dir" ]] || return 0
+
+  for cache_file in "$cache_dir"/*.json; do
+    [[ -f "$cache_file" ]] || continue
+    jq -e --arg url "$start_url" '.startUrl == $url' "$cache_file" >/dev/null 2>&1 || continue
+
+    expires_at="$(jq -r '.expiresAt // empty' "$cache_file")"
+    [[ -n "$expires_at" ]] || return 0
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+      normalized="${expires_at%Z}"
+      normalized="${normalized%%+*}"
+      expiry_epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "$normalized" +%s 2>/dev/null || echo "")
+    else
+      expiry_epoch=$(date -d "$expires_at" +%s 2>/dev/null || echo "")
+    fi
+
+    [[ -n "$expiry_epoch" ]] || return 0
+
+    now_epoch=$(date +%s)
+    remaining=$((expiry_epoch - now_epoch))
+    [[ $remaining -gt 0 ]] || return 0
+
+    printf "%d" "$remaining"
+    return 0
+  done
+}
+
 awx_profiles() {
-  # Only aws is needed here (no fzf/jq), so require_cmd aws is used directly
   require_cmd aws
+  require_cmd jq
   local filter_profile="${1:-}"
-  local profiles_out _awx_interrupted=0 _prev_int_trap
+  local profiles_out _awx_interrupted=0 _prev_int_trap remaining_str
 
   if [[ -n "$filter_profile" ]]; then
     profiles_out="$filter_profile"
@@ -454,7 +514,12 @@ awx_profiles() {
     if [[ "$_awx_interrupted" -eq 1 ]]; then break; fi
     if AWS_PAGER="" aws sts get-caller-identity \
       --profile "$profile" >/dev/null 2>&1; then
-      printf "%-40s ACTIVE\n" "$profile"
+      remaining_str="$(_sso_remaining "$profile")"
+      if [[ -n "$remaining_str" ]]; then
+        printf "%-40s ACTIVE (%s remaining)\n" "$profile" "$(format_duration "$remaining_str")"
+      else
+        printf "%-40s ACTIVE\n" "$profile"
+      fi
     else
       printf "%-40s EXPIRED\n" "$profile"
     fi

--- a/tests/profiles.bats
+++ b/tests/profiles.bats
@@ -70,3 +70,95 @@ EOF
   [[ "${output}" =~ "Missing dependency: aws" ]]
   export PATH="$PATH_BACKUP"
 }
+
+@test "awx profiles shows remaining duration for SSO profile with valid cache" {
+  cat >mock/bin/aws <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"configure list-profiles"* ]]; then
+  echo "sso-profile"
+elif [[ "$*" == *"configure get sso_start_url"* ]]; then
+  echo "https://my-sso.awsapps.com/start"
+elif [[ "$*" == *"sts get-caller-identity"* ]]; then
+  exit 0
+fi
+EOF
+  chmod +x mock/bin/aws
+
+  future_iso="$(date -v+5H -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -d "+5 hours" -u +%Y-%m-%dT%H:%M:%SZ)"
+  export AWX_SSO_CACHE_DIR="$(mktemp -d)"
+  cat > "$AWX_SSO_CACHE_DIR/cache.json" <<EOF
+{
+  "startUrl": "https://my-sso.awsapps.com/start",
+  "expiresAt": "$future_iso"
+}
+EOF
+
+  run ./awx profiles
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "sso-profile" ]]
+  [[ "${output}" =~ "ACTIVE" ]]
+  [[ "${output}" =~ "remaining" ]]
+}
+
+@test "awx profiles shows ACTIVE without duration for SSO profile with no cache" {
+  cat >mock/bin/aws <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"configure list-profiles"* ]]; then
+  echo "sso-profile"
+elif [[ "$*" == *"configure get sso_start_url"* ]]; then
+  echo "https://my-sso.awsapps.com/start"
+elif [[ "$*" == *"sts get-caller-identity"* ]]; then
+  exit 0
+fi
+EOF
+  chmod +x mock/bin/aws
+
+  export AWX_SSO_CACHE_DIR="$(mktemp -d)"
+
+  run ./awx profiles
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "ACTIVE" ]]
+  ! [[ "${output}" =~ "remaining" ]]
+}
+
+@test "awx profiles shows ACTIVE without duration for malformed cache" {
+  cat >mock/bin/aws <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"configure list-profiles"* ]]; then
+  echo "sso-profile"
+elif [[ "$*" == *"configure get sso_start_url"* ]]; then
+  echo "https://my-sso.awsapps.com/start"
+elif [[ "$*" == *"sts get-caller-identity"* ]]; then
+  exit 0
+fi
+EOF
+  chmod +x mock/bin/aws
+
+  export AWX_SSO_CACHE_DIR="$(mktemp -d)"
+  echo "not valid json" > "$AWX_SSO_CACHE_DIR/cache.json"
+
+  run ./awx profiles
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "ACTIVE" ]]
+  ! [[ "${output}" =~ "remaining" ]]
+}
+
+@test "format_duration formats hours and minutes" {
+  result=$(bash -c 'source ./awx 2>/dev/null; format_duration 18720')
+  [ "$result" = "5h 12m" ]
+}
+
+@test "format_duration formats minutes only" {
+  result=$(bash -c 'source ./awx 2>/dev/null; format_duration 2520')
+  [ "$result" = "42m" ]
+}
+
+@test "format_duration formats less than 1 minute" {
+  result=$(bash -c 'source ./awx 2>/dev/null; format_duration 30')
+  [ "$result" = "<1m" ]
+}
+
+@test "format_duration formats hours only" {
+  result=$(bash -c 'source ./awx 2>/dev/null; format_duration 3600')
+  [ "$result" = "1h" ]
+}


### PR DESCRIPTION
## Summary

Enhances `awx profiles` to display remaining AWS SSO session lifetime for active profiles.

**Before:**
```
clientA-dev     ACTIVE
clientB-prod    ACTIVE
clientC-stage   EXPIRED
```

**After:**
```
clientA-dev     ACTIVE (5h 12m remaining)
clientB-prod    ACTIVE (42m remaining)
clientC-stage   EXPIRED
```

## Changes

- **`format_duration()`** — converts seconds to human-readable `Xh Ym`, `Xm`, or `<1m`
- **`_sso_remaining()`** — reads AWS SSO cache files, matches by `sso_start_url`, calculates remaining seconds. Handles macOS/Linux `date` differences, malformed files, and missing cache gracefully
- **`awx_profiles()`** — now requires `jq`; displays remaining duration for active SSO profiles. Static credential profiles show `ACTIVE` without duration (backward compatible)
- **Configurable** via `AWX_SSO_CACHE_DIR` env var (default: `~/.aws/sso/cache`)
- **7 new bats tests** covering valid cache, missing cache, malformed cache, and `format_duration` helper

## Testing

- All 122 bats tests pass
- `shellcheck awx` — clean
- All pre-commit hooks pass

Closes #70