### PR TITLE
fix(error-handling): standardize die behavior for sourced vs standalone execution (closes #9)

### DIFF
--- a/awx
+++ b/awx
@@ -85,7 +85,7 @@ error() {
 
 die() {
   error "$*"
-  return 1
+  [[ "$_awx_is_sourced" -eq 1 ]] && return 1 || exit 1
 }
 
 require_cmd() {
@@ -141,9 +141,9 @@ aws_ensure_session() {
         return 0
       fi
 
-      # die() only returns 1 — it does not exit the function. An explicit
-      # return 1 is required here because set -e is suspended when this
-      # function is invoked in a || context (e.g. from list_clusters).
+      # die() exits when standalone, returns 1 when sourced. The explicit
+      # return 1 after die() is a no-op for standalone (die already exited)
+      # but ensures the calling function returns when sourced.
       die "SSO session not ready after login. Please run 'awx use' again."
       return 1
     fi
@@ -154,8 +154,9 @@ aws_ensure_session() {
       return 0
     fi
 
-    # die() only returns 1 — explicit return 1 guards against fall-through
-    # when set -e is suspended in a || context.
+    # die() exits when standalone, returns 1 when sourced. The explicit
+    # return 1 after die() is a no-op for standalone (die already exited)
+    # but ensures the calling function returns when sourced.
     die "AWS SSO login failed for profile: $profile"
     return 1
   elif [[ -n "$static_key" ]]; then

--- a/tests/error_handling.bats
+++ b/tests/error_handling.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+@test "die exits with nonzero status when script is executed standalone" {
+  run ./awx --bogus-flag
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"Unknown flag"* ]]
+}
+
+@test "die returns without exiting when sourced" {
+  run bash -c 'source ./awx; die "test sourced error"; echo "ALIVE"'
+  [ "$status" -eq 0 ]
+  [[ "${output}" == *"test sourced error"* ]]
+  [[ "${output}" == *"ALIVE"* ]]
+}
+
+@test "no unexpected shell termination when sourced with die" {
+  run bash -c '
+    source ./awx
+    wrapper() { die "error from function"; }
+    wrapper
+    echo "SHELL_ALIVE"
+  '
+  [ "$status" -eq 0 ]
+  [[ "${output}" == *"error from function"* ]]
+  [[ "${output}" == *"SHELL_ALIVE"* ]]
+}
+
+@test "die in || context returns when sourced (no shell exit)" {
+  run bash -c 'source ./awx; false || die "or failure"; echo "ALIVE"'
+  [ "$status" -eq 0 ]
+  [[ "${output}" == *"or failure"* ]]
+  [[ "${output}" == *"ALIVE"* ]]
+}


### PR DESCRIPTION
## Summary

Standardizes `die()` to:
- **`exit 1`** when script is executed standalone — explicitly terminates even inside `||` contexts where `set -e` is suspended
- **`return 1`** when sourced — safe return without killing the parent shell

Closes #9