### PR TITLE
feat(ctx): add awx ctx command for kubeconfig context switching (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _Blazginly Fast AWS Profile & EKS Context Switcher_
 
 - Fuzzy, interactive AWS profile selection via [`fzf`](https://github.com/junegunn/fzf) but also non-interactive mode: `awx use --profile X --cluster Y` for scripts and automation
 - Toggle back to the previous AWS profile and EKS cluster with **`awx -`** (like `cd -`)
+- Switch between existing kubeconfig contexts interactively with **`awx ctx`**
 - Zsh tab completion for commands, subcommands, and AWS profile names
 - Automatic SSO session re-authentication on every profile switch: if your session expires mid-day, `awx` detects it and re-authenticates transparently, with graceful fallback to static credentials when SSO fails
 - EKS kubeconfig management with caching that skips redundant updates when the target context already exists
@@ -41,6 +42,7 @@ awx --profile my-profile                     # Top-level flag (equivalent to abo
 awx whoami                                   # Show current AWS identity
 awx eks list                                 # List available EKS clusters for active profile
 awx eks update                               # Update kubeconfig for a specific cluster
+awx ctx                                      # Switch kubeconfig context via fzf
 awx help or -h                               # Show detailed usage instructions
 awx logout                                   # Logout of the current AWS SSO session
 awx profiles                                 # List all configured AWS profiles with ACTIVE/EXPIRED status and remaining session time

--- a/awx
+++ b/awx
@@ -493,6 +493,20 @@ _sso_remaining() {
   done
 }
 
+awx_ctx() {
+  require_cmd kubectl
+  local ctx
+  local contexts
+  contexts="$(kubectl config get-contexts -o name 2>/dev/null || true)"
+  if [[ -z "$contexts" ]]; then
+    warn "No kubeconfig contexts available"
+    return 1
+  fi
+  ctx="$(printf "%s\n" "$contexts" | fzf --prompt="Select context: ")" || return 1
+  kubectl config use-context "$ctx" >/dev/null
+  log "Switched to context: $ctx"
+}
+
 awx_profiles() {
   require_cmd aws
   require_cmd jq
@@ -642,7 +656,7 @@ awx_prev() {
   # profile (e.g. 'awx profiles' treated as a profile shortcut before the
   # command was registered in the dispatcher).
   case "$prev_profile" in
-    use | whoami | profiles | eks | logout | help | -)
+    use | whoami | profiles | eks | logout | ctx | help | -)
       die "State file contains reserved name '$prev_profile' as a profile — likely caused by sourcing an old version of awx. Delete $AWX_STATE_FILE to reset."
       ;;
   esac
@@ -692,6 +706,7 @@ EOF
   echo "  eks update                        Update kubeconfig for a specific EKS cluster"
   echo "  logout                            Logout of the current AWS SSO session"
   echo "  update                            Update awx to the latest version from GitHub"
+  echo "  ctx                               Switch kubeconfig context via fzf"
   echo "  -                                 Toggle back to previous AWS profile/cluster (like cd -)"
   echo "  help | -h                         Show this help message"
 }
@@ -723,6 +738,9 @@ awx() {
       ;;
     help | -h | --help)
       show_help
+      ;;
+    ctx)
+      awx_ctx
       ;;
     -)
       awx_prev

--- a/completions/_awx
+++ b/completions/_awx
@@ -17,6 +17,7 @@ _awx() {
     'use:Select AWS profile and update kubeconfig'
     'whoami:Display current AWS identity'
     'profiles:List all configured profiles with session status'
+    'ctx:Switch kubeconfig context via fzf'
     'eks:Manage EKS clusters'
     'logout:Logout of current AWS SSO session'
     'update:Update awx to the latest version from GitHub'

--- a/tests/ctx.bats
+++ b/tests/ctx.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+setup() {
+  export KUBECONFIG="$(pwd)/test-config/kubeconfig"
+  export AWS_PROFILE="test-profile"
+}
+
+teardown() {
+  rm -rf test-config mock
+}
+
+@test "awx ctx selects and switches to a context via fzf" {
+  mkdir -p mock/bin test-config
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/kubectl <<'EOM'
+#!/bin/bash
+if [[ "$*" == *"get-contexts"* ]]; then
+  echo "dev-cluster"
+  echo "prod-cluster"
+elif [[ "$*" == *"use-context"* ]]; then
+  echo "Switched to context $3"
+else
+  echo "unexpected kubectl invocation: $*" >&2
+  exit 1
+fi
+EOM
+  chmod +x mock/bin/kubectl
+
+  cat >mock/bin/fzf <<'EOM'
+#!/bin/bash
+head -n1
+EOM
+  chmod +x mock/bin/fzf
+
+  run ./awx ctx
+
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "Switched to context: dev-cluster" ]]
+}
+
+@test "awx ctx warns when no contexts available" {
+  mkdir -p mock/bin test-config
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/kubectl <<'EOM'
+#!/bin/bash
+if [[ "$*" == *"get-contexts"* ]]; then
+  exit 0
+fi
+EOM
+  chmod +x mock/bin/kubectl
+
+  run ./awx ctx
+
+  [ "$status" -eq 1 ]
+  [[ "${output}" =~ "No kubeconfig contexts available" ]]
+}
+
+@test "awx ctx fails when kubectl is missing" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  ln -s "$(command -v bash)" "$tmpdir/bash"
+  PATH="$tmpdir" run ./awx ctx
+  rm -rf "$tmpdir"
+
+  [ "$status" -ne 0 ]
+  [[ "${output}" =~ "Missing dependency: kubectl" ]]
+}


### PR DESCRIPTION
## Summary

- `awx ctx` opens an fzf picker of all kubeconfig contexts from `kubectl config get-contexts`
- Selecting a context switches to it with `kubectl config use-context`
- Running `awx ctx` with no contexts available prints a clear warning
- `awx help` documents the new `ctx` command
- 3 bats tests cover: successful selection, no-contexts warning, missing kubectl
- Zsh completions and README updated

Closes #22