### PR TITLE
feat: add utility commands (current, clear, refresh) (closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ _Blazginly Fast AWS Profile & EKS Context Switcher_
 - Automatic SSO session re-authentication on every profile switch: if your session expires mid-day, `awx` detects it and re-authenticates transparently, with graceful fallback to static credentials when SSO fails
 - EKS kubeconfig management with caching that skips redundant updates when the target context already exists
 - Lists all configured AWS profiles with `ACTIVE`/`EXPIRED` session status and remaining SSO session lifetime via **`awx profiles`**
+- Display the active profile, region, and EKS cluster with **`awx current`**
+- Reset environment and clear cached data with **`awx clear`**
+- Force refresh of SSO session with **`awx refresh`**
 
 ## Usage
 `awx` is a versatile script for managing AWS profiles and EKS kubeconfig contexts. Below are the primary commands and their purposes:
@@ -40,6 +43,9 @@ awx --profile my-profile                     # Top-level flag (equivalent to abo
 
 # Other commands
 awx whoami                                   # Show current AWS identity
+awx current                                  # Show current profile, region, and cluster
+awx clear                                    # Unset AWS env vars and clear cache/state
+awx refresh                                  # Force refresh of SSO session
 awx eks list                                 # List available EKS clusters for active profile
 awx eks update                               # Update kubeconfig for a specific cluster
 awx ctx                                      # Switch kubeconfig context via fzf

--- a/awx
+++ b/awx
@@ -40,7 +40,7 @@ AWX_CACHE_TTL="${AWX_CACHE_TTL:-480}" # Cache TTL in minutes (default: 8h)
 # ---------------------------------------------------------------------------
 # State management — persists current/previous environment for `awx -`
 # ---------------------------------------------------------------------------
-AWX_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/awx"
+AWX_STATE_DIR="${AWX_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/awx}"
 AWX_STATE_FILE="${AWX_STATE_FILE:-$AWX_STATE_DIR/env}"
 
 _awx_state_ensure_dir() {
@@ -631,6 +631,79 @@ awx_logout() {
   fi
 }
 
+awx_current() {
+  local profile="${AWS_PROFILE:-}"
+  local region="${AWS_REGION:-$DEFAULT_REGION}"
+  local cluster=""
+
+  if command -v kubectl >/dev/null 2>&1; then
+    cluster="$(kubectl config current-context 2>/dev/null || true)"
+  fi
+
+  if [[ -z "$profile" ]]; then
+    printf "Profile: <unset>  Region: %s" "$region"
+  else
+    printf "Profile: %s  Region: %s" "$profile" "$region"
+  fi
+
+  if [[ -n "$cluster" ]]; then
+    printf "  Cluster: %s" "$cluster"
+  fi
+  printf "\n"
+}
+
+awx_clear() {
+  unset AWS_PROFILE
+  unset AWS_REGION
+  unset AWS_DEFAULT_REGION
+
+  if [[ -d "$AWX_CACHE_DIR" ]]; then
+    rm -rf "$AWX_CACHE_DIR"
+  fi
+  if [[ -d "$AWX_STATE_DIR" ]]; then
+    rm -rf "$AWX_STATE_DIR"
+  fi
+
+  log "Cleared AWS environment variables, EKS cache, and state"
+}
+
+awx_refresh() {
+  local profile="${AWS_PROFILE:-}"
+
+  if [[ -z "$profile" ]]; then
+    error "AWS_PROFILE not set. Please run: awx use"
+    return 1
+  fi
+
+  if [[ -d "$AWX_SSO_CACHE_DIR" ]]; then
+    rm -rf "$AWX_SSO_CACHE_DIR"
+    log "Cleared SSO token cache"
+  fi
+
+  log "Refreshing SSO session for profile: $profile"
+  if aws sso login --profile "$profile"; then
+    local sts_ready=0
+    for ((i = 0; i < AWX_STS_RETRIES; i++)); do
+      if aws sts get-caller-identity --profile "$profile" >/dev/null 2>&1; then
+        sts_ready=1
+        break
+      fi
+      log "Waiting for SSO session to stabilize..."
+      sleep 1
+    done
+
+    if [[ "$sts_ready" -eq 1 ]]; then
+      log "SSO session refreshed for profile: $profile"
+      return 0
+    fi
+    die "SSO session not ready after refresh. Try again."
+    return 1
+  fi
+
+  die "AWS SSO login failed for profile: $profile"
+  return 1
+}
+
 awx_prev() {
   local prev_line
   prev_line="$(_awx_state_read_previous)"
@@ -656,7 +729,7 @@ awx_prev() {
   # profile (e.g. 'awx profiles' treated as a profile shortcut before the
   # command was registered in the dispatcher).
   case "$prev_profile" in
-    use | whoami | profiles | eks | logout | ctx | help | -)
+    use | whoami | profiles | eks | logout | ctx | help | - | current | clear | refresh)
       die "State file contains reserved name '$prev_profile' as a profile — likely caused by sourcing an old version of awx. Delete $AWX_STATE_FILE to reset."
       ;;
   esac
@@ -705,6 +778,9 @@ EOF
   echo "  eks list                          List EKS clusters for the active profile"
   echo "  eks update                        Update kubeconfig for a specific EKS cluster"
   echo "  logout                            Logout of the current AWS SSO session"
+  echo "  current                           Show current AWS profile, region, and cluster"
+  echo "  clear                             Unset AWS environment variables and clear cache"
+  echo "  refresh                           Force refresh of SSO session"
   echo "  update                            Update awx to the latest version from GitHub"
   echo "  ctx                               Switch kubeconfig context via fzf"
   echo "  -                                 Toggle back to previous AWS profile/cluster (like cd -)"
@@ -735,6 +811,15 @@ awx() {
       ;;
     update)
       awx_update
+      ;;
+    current)
+      awx_current
+      ;;
+    clear)
+      awx_clear
+      ;;
+    refresh)
+      awx_refresh
       ;;
     help | -h | --help)
       show_help

--- a/tests/utils.bats
+++ b/tests/utils.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+setup() {
+  export AWX_CACHE_DIR="$(mktemp -d)"
+  export AWX_STATE_DIR="$(mktemp -d)"
+  export AWX_SSO_CACHE_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "${AWX_CACHE_DIR:-}"
+  rm -rf "${AWX_STATE_DIR:-}"
+  rm -rf "${AWX_SSO_CACHE_DIR:-}"
+  rm -rf mock
+}
+
+@test "awx current with AWS_PROFILE set" {
+  export AWS_PROFILE="test-profile"
+  export AWS_REGION="eu-west-1"
+  run ./awx current
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "Profile: test-profile" ]]
+  [[ "${output}" =~ "Region: eu-west-1" ]]
+}
+
+@test "awx current with AWS_PROFILE unset" {
+  unset AWS_PROFILE
+  export AWS_REGION="eu-west-1"
+  run ./awx current
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "Profile: <unset>" ]]
+}
+
+@test "awx current with kubectl context available" {
+  export AWS_PROFILE="test-profile"
+  export AWS_REGION="eu-central-1"
+
+  mkdir -p mock/bin
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/kubectl <<'EOM'
+#!/bin/bash
+if [[ "$*" == "config current-context" ]]; then
+  echo "test-cluster"
+  exit 0
+fi
+exit 1
+EOM
+  chmod +x mock/bin/kubectl
+
+  run ./awx current
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "test-cluster" ]]
+}
+
+@test "awx clear unsets environment variables" {
+  source ./awx
+  export AWS_PROFILE="test-profile"
+  export AWS_REGION="eu-central-1"
+  export AWS_DEFAULT_REGION="eu-central-1"
+
+  awx_clear
+
+  [[ -z "${AWS_PROFILE:-}" ]]
+  [[ -z "${AWS_REGION:-}" ]]
+  [[ -z "${AWS_DEFAULT_REGION:-}" ]]
+}
+
+@test "awx clear removes cache and state directories" {
+  touch "$AWX_CACHE_DIR/some_cache_file"
+  touch "$AWX_STATE_DIR/some_state_file"
+
+  run ./awx clear
+
+  [ "$status" -eq 0 ]
+  [[ ! -d "$AWX_CACHE_DIR" ]]
+  [[ ! -d "$AWX_STATE_DIR" ]]
+}
+
+@test "awx refresh without AWS_PROFILE returns error" {
+  unset AWS_PROFILE
+  run ./awx refresh
+  [ "$status" -ne 0 ]
+  [[ "${output}" =~ "AWS_PROFILE not set" ]]
+}
+
+@test "awx refresh with SSO profile clears cache and logs in" {
+  mkdir -p mock/bin
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  touch "$AWX_SSO_CACHE_DIR/botocore-client-id.json"
+  touch "$AWX_SSO_CACHE_DIR/abcd1234.json"
+
+  cat >mock/bin/aws <<'EOM'
+#!/bin/bash
+if [[ "$*" == "sso login"* ]]; then
+  exit 0
+elif [[ "$*" == sts* ]]; then
+  echo '{"UserId":"X","Account":"123","Arn":"arn:aws:iam::123:user/x"}'
+  exit 0
+fi
+exit 1
+EOM
+  chmod +x mock/bin/aws
+
+  cat >mock/bin/jq <<'EOM'
+#!/bin/bash
+exit 0
+EOM
+  chmod +x mock/bin/jq
+
+  export AWS_PROFILE="test-profile"
+
+  run ./awx refresh
+
+  [ "$status" -eq 0 ]
+  [[ "${output}" =~ "Cleared SSO token cache" ]]
+  [[ "${output}" =~ "SSO session refreshed for profile: test-profile" ]]
+}
+
+@test "awx refresh with failed SSO login" {
+  mkdir -p mock/bin
+  export PATH="$(pwd)/mock/bin:$PATH"
+
+  cat >mock/bin/aws <<'EOM'
+#!/bin/bash
+if [[ "$*" == "sso login"* ]]; then
+  echo "SSO login failed" >&2
+  exit 1
+fi
+exit 1
+EOM
+  chmod +x mock/bin/aws
+
+  export AWS_PROFILE="test-profile"
+
+  run ./awx refresh
+
+  [ "$status" -ne 0 ]
+  [[ "${output}" =~ "AWS SSO login failed" ]]
+}


### PR DESCRIPTION
## Summary
- **`awx current`** — show active AWS profile, region, and EKS cluster (via `kubectl config current-context`)
- **`awx clear`** — unset `AWS_PROFILE`/`AWS_REGION`/`AWS_DEFAULT_REGION` and remove cache/state directories
- **`awx refresh`** — clear SSO token cache and force `aws sso login` with STS verification

## Related Issues
Closes #13

## Testing
- 8 new bats tests in `tests/utils.bats`
- All 137 tests passing
- shellcheck + pre-commit green